### PR TITLE
Configure babel es2015 preset

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ var Elixir = require('laravel-elixir');
 Elixir.ready(function() {
     Elixir.webpack.mergeConfig({
         babel: {
-            presets: ['es2015'],
+            presets: ['es2015', { modules: false }],
             plugins: ['add-module-exports', 'transform-runtime'],
         },
         module: {


### PR DESCRIPTION
Hi @JeffreyWay,

I've been having the same issue as described in #3 and I have used `master` branch to try the potential fix that was merged from #4. It worked for the most part - all my `.vue` files compiled fine, but then none of my `.js` modules got loaded (can't find a better description for this issue).

Anyway, after some digging, looks like passing an option to disable module transformation does the trick. Perhaps this is valid fix?
