### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-vue",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Laravel Elixir Vue Integration",
   "main": "main.js",
   "keywords": [


### PR DESCRIPTION
Bump version to 0.1.5, since `npm i laravel-elixir-vue` installs 0.1.4 with the old preset `['es2015-webpack']`
