### PR TITLE
Add sass-loader to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-es2015": "^6.13.2",
     "babel-runtime": "^6.9.0",
     "css-loader": "^0.23.1",
+    "sass-loader": "^4.0.2",
     "vue": "^1.0.24",
     "vue-hot-reload-api": "^1.3.2",
     "vue-html-loader": "^1.2.2",


### PR DESCRIPTION
This adds the `sass-loader` module by default so we can do:

``` html
<style lang="sass">
...
</style>
```

Seems like a nice thing to do. The Vue.js v2 [version of this](https://github.com/vuejs/laravel-elixir-vue-2/blob/master/package.json) is doing it, too.
